### PR TITLE
Revamp newsletter style with playful links

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,77 +8,74 @@
   </head>
   <body>
     <header>
-      <h1>I'm an h1</h1>
-      <p class="tagline">Insert witty tagline here.</p>
+      <h1>The Daily CSS Times</h1>
+      <p class="tagline">Your weekly dose of style and mischief.</p>
     </header>
     <nav>
       <ul>
-        <li><a class="red-link" href="http://example.com/">Link</a></li>
-        <li><a class="red-link" href="http://example.com/">Link</a></li>
-        <li><a class="red-link" href="http://example.com/">Link</a></li>
+        <li><a class="red-link" href="#">Home</a></li>
+        <li><a class="red-link" href="#">Archives</a></li>
+        <li><a class="red-link" href="#">Subscribe</a></li>
       </ul>
     </nav>
     <article>
-      <h2>I'm an h2</h2>
-      <div class="boxed"><a class="green-link" href="http://example.com/">I'm a link</a></div>
-      <div class="boxed"><a class="green-link" href="http://example.com/">I'm a link</a></div>
-      <div class="boxed"><a class="green-link" href="http://example.com/">I'm a link</a></div>
-      <div class="boxed"><a class="green-link" href="http://example.com/">I'm a link</a></div>
+      <h2>Welcome to this week's edition!</h2>
+      <p>We've gathered the latest news for you below.</p>
       <section class="ai-update">
-        <h3>OpenAI Codex</h3>
+        <h3>OpenAI <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Codex</a></h3>
         <h4>What's new</h4>
         <ul>
-          <li>OpenAI recently launched Codex, a cloud-based AI coding agent built on the codex-1 model (part of the o3 family). It helps developers write code, fix bugs, run tests, and explore codebases—all within ChatGPT’s interface.</li>
+          <li>OpenAI recently launched <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Codex</a>, a cloud-based AI coding agent built on the codex-1 model (part of the o3 family). It helps developers write code, fix bugs, run tests, and explore codebases—all within ChatGPT’s interface.</li>
           <li>Released as a research preview around May 16–17, 2025, it’s available to Pro, Team, and Enterprise users. Early adopters such as Cisco, Temporal, and Superhuman have already started using it.</li>
           <li>A console/CLI version is also available for developers preferring terminal-based workflows.</li>
-          <li>Codex introduces transparency features: it works step-by-step and flags uncertainties, addressing common AI coding tool concerns.</li>
+          <li><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Codex</a> introduces transparency features: it works step-by-step and flags uncertainties, addressing common AI coding tool concerns.</li>
         </ul>
         <h4>Significance</h4>
-        <p>Codex represents a major step toward more autonomous coding agents, capable of parallel task execution—writing features, testing, bug fixes—and improving developer workflows through visible reasoning channels.</p>
+        <p><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Codex</a> represents a major step toward more autonomous coding agents, capable of parallel task execution—writing features, testing, bug fixes—and improving developer workflows through visible reasoning channels.</p>
 
-        <h3>OpenAI New Tool Support via Responses API</h3>
+        <h3>OpenAI New Tool Support via <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Responses API</a></h3>
         <h4>Overview</h4>
         <ul>
-          <li>In March 2025, OpenAI launched the Responses API, a new interface combining features of Chat Completions and Assistants API, designed for building agentic applications.</li>
+          <li>In March 2025, OpenAI launched the <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Responses API</a>, a new interface combining features of Chat Completions and Assistants API, designed for building agentic applications.</li>
           <li>It natively supports tools such as web search, file search, and computer use, simplifying agent orchestration.</li>
-          <li>Recent updates (May 21, 2025) enhanced the Responses API with Remote Model Context Protocol (MCP) server support, image generation, Code Interpreter, and improved file search capabilities.</li>
+          <li>Recent updates (May 21, 2025) enhanced the <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Responses API</a> with Remote Model Context Protocol (MCP) server support, image generation, Code Interpreter, and improved file search capabilities.</li>
         </ul>
         <h4>Impact for developers</h4>
         <p>This new API streamlines building multi-tool workflows—allowing LLMs to handle search, analysis, code execution, and file interaction seamlessly. It’s a foundational shift toward more autonomous, tool-powered agent applications.</p>
 
         <h3>Google I/O 2025 Keynote Announcements</h3>
         <p>Google’s annual I/O keynote (May 20, 2025) had a strong AI focus. Highlights include:</p>
-        <h4>Gemini &amp; AI Mode</h4>
+        <h4>Gemini &amp; <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">AI Mode</a></h4>
         <ul>
-          <li>Gemini 2.5 Pro launched with a “Deep Think” reasoning enhancement, including Gemini Flash for faster responses.</li>
-          <li>AI Mode for Google Search is rolling out in the U.S., enabling a chat-like experience and agentic capabilities such as “deep search” and proactive task completion via Project Mariner.</li>
+          <li><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Gemini 2.5 Pro</a> launched with a “Deep Think” reasoning enhancement, including <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Gemini Flash</a> for faster responses.</li>
+          <li><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">AI Mode</a> for Google Search is rolling out in the U.S., enabling a chat-like experience and agentic capabilities such as “<a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">deep search</a>” and proactive task completion via <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Project Mariner</a>.</li>
         </ul>
         <h4>Creative AI Tools</h4>
         <ul>
-          <li>Veo 3, Imagen 4, and Flow for text-to-image/video creation and AI filmmaking.</li>
+          <li><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Veo 3</a>, <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Imagen 4</a>, and <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Flow</a> for text-to-image/video creation and AI filmmaking.</li>
         </ul>
         <h4>Agent Platforms &amp; Smart Devices</h4>
         <ul>
-          <li>Project Astra: AI assistant capable of real-time visual task handling.</li>
-          <li>Gemini Live: Integrates camera, voice, and web data for a unified assistant experience.</li>
-          <li>Android XR / Smart Glasses: A new wearable AR platform, extending into smart glasses designed to replace phones.</li>
+          <li><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Project Astra</a>: AI assistant capable of real-time visual task handling.</li>
+          <li><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Gemini Live</a>: Integrates camera, voice, and web data for a unified assistant experience.</li>
+          <li><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Android XR / Smart Glasses</a>: A new wearable AR platform, extending into smart glasses designed to replace phones.</li>
         </ul>
         <h4>Collaboration Tools &amp; Workspace AI</h4>
         <ul>
-          <li>Google Beam (formerly Project Starline): 3D video calling with immersive lightfield displays.</li>
-          <li>Workspace enhancements: Smart Replies in Gmail, AI-driven Meet translation, video creation in Vids, and more.</li>
+          <li><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Google Beam</a> (formerly Project Starline): 3D video calling with immersive lightfield displays.</li>
+          <li><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Workspace enhancements</a>: Smart Replies in Gmail, AI-driven Meet translation, video creation in Vids, and more.</li>
         </ul>
         <h4>Automotive &amp; Other</h4>
         <ul>
           <li>Android Auto will soon support video, browser, and a broader app ecosystem.</li>
-          <li>AI Ultra subscription: A $249.99/month premium tier offering full AI services (Gemini 2.5 Pro, Flow, etc.), targeting power users and developers.</li>
+          <li><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">AI Ultra subscription</a>: A $249.99/month premium tier offering full AI services (<a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Gemini 2.5 Pro</a>, <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Flow</a>, etc.), targeting power users and developers.</li>
           <li>Alphabet stock rose ~5% after Google I/O amid investor enthusiasm for AI initiatives.</li>
         </ul>
 
-        <h3>Anthropic Livestream Tomorrow (May 22, 2025)</h3>
+        <h3><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Anthropic</a> Livestream Tomorrow (May 22, 2025)</h3>
         <ul>
-          <li>Event: Code with Claude 2025, Anthropic’s first developer conference, livestreamed on May 22, 2025 at 9:30 AM PT / 11:30 AM CT in San Francisco.</li>
-          <li>Focus: Hands-on sessions showcasing Anthropic API, CLI tools, and their Model Context Protocol (MCP). Expect demos and best practices with Claude-based tools.</li>
+          <li>Event: <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Code with Claude 2025</a>, <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Anthropic</a>’s first developer conference, livestreamed on May 22, 2025 at 9:30 AM PT / 11:30 AM CT in San Francisco.</li>
+          <li>Focus: Hands-on sessions showcasing <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Anthropic</a> API, CLI tools, and their Model Context Protocol (MCP). Expect demos and best practices with Claude-based tools.</li>
         </ul>
 
         <h3>Quick Links</h3>
@@ -87,14 +84,15 @@
             <tr><th>Topic</th><th>Link</th></tr>
           </thead>
           <tbody>
-            <tr><td>OpenAI Codex Announcement</td><td>E-Week summary &amp; details</td></tr>
-            <tr><td>Responses API + Tool Support</td><td>OpenAI blog &amp; updates</td></tr>
+            <tr><td>OpenAI <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Codex</a> Announcement</td><td>E-Week summary &amp; details</td></tr>
+            <tr><td><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Responses API</a> + Tool Support</td><td>OpenAI blog &amp; updates</td></tr>
             <tr><td>Google I/O 2025 Recap</td><td>Wired, The Verge coverage</td></tr>
-            <tr><td>Anthropic Livestream Info</td><td>Anthropic Events page</td></tr>
+            <tr><td><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Anthropic</a> Livestream Info</td><td><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Anthropic</a> Events page</td></tr>
           </tbody>
         </table>
 
-        <p>Let me know if you’d like a deeper dive into any of these—like a breakdown of Gemini’s new features, Codex usage examples, or Anthropic session prep!</p>
+        <p>Let me know if you’d like a deeper dive into any of these—like a breakdown of Gemini’s new features, <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Codex</a> usage examples, or <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Anthropic</a> session prep!</p>
+        <p>Thanks for reading! See you next time.</p>
       </section>
     </article>
     <aside>

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,11 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 600px;
+  margin: auto;
+  background: #f9f9f9;
+  padding: 1em;
+}
+
 .red-link {
   color: red;
 }
@@ -20,3 +28,9 @@
   color: #555;
   font-size: 0.9em;
 }
+
+header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+


### PR DESCRIPTION
## Summary
- update newsletter header and nav links
- remove placeholder content and add humorous sign-off
- pepper headlines with joke links to a classic video
- style body and header for a friendlier newsletter feel

## Testing
- `pytest` *(fails: command not found)*